### PR TITLE
[findpt] No more setup inside findpt_eval

### DIFF
--- a/src/findpts_imp.h
+++ b/src/findpts_imp.h
@@ -266,6 +266,62 @@ void findptsms_free(struct findpts_data *fd)
   free(fd);
 }
 
+
+struct eval_src_pt { double r[D]; uint index, proc, el; };
+struct eval_out_pt { double out; uint index, proc; };
+
+static void setup_fev_aux(
+  const uint   *const code_base, const unsigned code_stride,
+  const uint   *const proc_base, const unsigned proc_stride,
+  const uint   *const   el_base, const unsigned   el_stride,
+  const double *const    r_base, const unsigned    r_stride,
+  const uint npt, struct findpts_data *const fd)
+{
+  struct array src;
+  /* copy user data, weed out unfound points, send out */
+  {
+    uint index;
+    const uint *code=code_base, *proc=proc_base, *el=el_base;
+    const double *r=r_base;
+    struct eval_src_pt *pt;
+    array_init(struct eval_src_pt, &src, npt), pt=src.ptr;
+    for(index=0;index<npt;++index) {
+      if(*code!=CODE_NOT_FOUND) {
+        unsigned d;
+        for(d=0;d<D;++d) pt->r[d]=r[d];
+        pt->index=index;
+        pt->proc=*proc;
+        pt->el=*el;
+        ++pt;
+      }
+      r    = (const double*)((const char*)r   +   r_stride);
+      code = (const   uint*)((const char*)code+code_stride);
+      proc = (const   uint*)((const char*)proc+proc_stride);
+      el   = (const   uint*)((const char*)el  +  el_stride);
+    }
+    src.n = pt - (struct eval_src_pt*)src.ptr;
+    sarray_transfer(struct eval_src_pt,&src,proc,1,&fd->cr);
+  }
+  /* setup space for source points*/
+  {
+    uint n=src.n;
+    uint d;
+    const struct eval_src_pt *spt;
+    struct eval_src_pt *opt;
+    /* group points by element */
+    sarray_sort(struct eval_src_pt,src.ptr,n, el,0, &fd->cr.data);
+    array_init(struct eval_src_pt,&fd->savpt,n), fd->savpt.n=n;
+    spt=src.ptr, opt=fd->savpt.ptr;
+    for(;n;--n,++spt,++opt) {
+        opt->index= spt->index;
+        opt->proc = spt->proc;
+        opt->el   = spt->el  ;
+        for(d=0;d<D;++d) opt->r[d] = spt->r[d];
+    }
+    array_free(&src);
+  }
+}
+
 struct src_pt { double x[D]; uint index, proc, session_id; };
 struct out_pt { double r[D], dist2, disti; uint index, code, el, proc, elsid; };
 
@@ -521,60 +577,14 @@ void findptsms(        uint   *const        code_base, const unsigned       code
   }
   free(distv);
   free(elsidv);
-}
-
-struct eval_src_pt { double r[D]; uint index, proc, el; };
-struct eval_out_pt { double out; uint index, proc; };
-
-static void setup_fev_aux(
-  const uint   *const code_base, const unsigned code_stride,
-  const uint   *const proc_base, const unsigned proc_stride,
-  const uint   *const   el_base, const unsigned   el_stride,
-  const double *const    r_base, const unsigned    r_stride,
-  const uint npt, struct findpts_data *const fd)
-{
-  struct array src;
-  /* copy user data, weed out unfound points, send out */
-  {
-    uint index;
-    const uint *code=code_base, *proc=proc_base, *el=el_base;
-    const double *r=r_base;
-    struct eval_src_pt *pt;
-    array_init(struct eval_src_pt, &src, npt), pt=src.ptr;
-    for(index=0;index<npt;++index) {
-      if(*code!=CODE_NOT_FOUND) {
-        unsigned d;
-        for(d=0;d<D;++d) pt->r[d]=r[d];
-        pt->index=index;
-        pt->proc=*proc;
-        pt->el=*el;
-        ++pt;
-      }
-      r    = (const double*)((const char*)r   +   r_stride);
-      code = (const   uint*)((const char*)code+code_stride);
-      proc = (const   uint*)((const char*)proc+proc_stride);
-      el   = (const   uint*)((const char*)el  +  el_stride);
-    }
-    src.n = pt - (struct eval_src_pt*)src.ptr;
-    sarray_transfer(struct eval_src_pt,&src,proc,1,&fd->cr);
-  }
-  /* setup space for source points*/
-  {
-    uint n=src.n;
-    uint d;
-    const struct eval_src_pt *spt;
-    struct eval_src_pt *opt;
-    /* group points by element */
-    sarray_sort(struct eval_src_pt,src.ptr,n, el,0, &fd->cr.data);
-    array_init(struct eval_src_pt,&fd->savpt,n), fd->savpt.n=n;
-    spt=src.ptr, opt=fd->savpt.ptr;
-    for(;n;--n,++spt,++opt) {
-        opt->index= spt->index;
-        opt->proc = spt->proc;
-        opt->el   = spt->el  ;
-        for(d=0;d<D;++d) opt->r[d] = spt->r[d];
-    }
-    array_free(&src);
+  
+  if (fd->fevsetup==0) {
+    setup_fev_aux(code_base,code_stride,
+                  proc_base,proc_stride,
+                    el_base,  el_stride,
+                     r_base,   r_stride,
+                        npt,         fd);
+    fd->fevsetup=1;
   }
 }
 
@@ -588,13 +598,10 @@ void findptsms_eval(
   const double *const in, struct findpts_data *const fd)
 { 
   if (fd->fevsetup==0) {
-    setup_fev_aux(code_base,code_stride,
-                  proc_base,proc_stride,
-                    el_base,  el_stride,
-                     r_base,   r_stride,
-                        npt,         fd);
-    fd->fevsetup=1;
+     printf("Please call findpt in advance\n");
+     die(1);
   }
+  
   struct array outpt;
   /* evaluate points, send back */
   { 


### PR DESCRIPTION
In order to reuse `findpt_eval`, I propose moving the `setup_fev_aux` from `findpt_eval` to `findpt`