### PR TITLE
Fix three compiler warnings

### DIFF
--- a/src/findpts_imp.h
+++ b/src/findpts_imp.h
@@ -278,7 +278,10 @@ void findptsms(        uint   *const        code_base, const unsigned       code
                  const uint   *const session_id_match, const uint                   npt,
                        struct findpts_data *const fd)
 {
-  if (fd->fevsetup==1) array_free(&fd->savpt); fd->fevsetup=0;
+  if (fd->fevsetup==1) {
+    array_free(&fd->savpt);
+    fd->fevsetup=0;
+  }
   const uint np = fd->cr.comm.np, id=fd->cr.comm.id;
   struct array hash_pt, src_pt, out_pt;
   double *distv = tmalloc(double,npt);

--- a/src/findpts_imp.h
+++ b/src/findpts_imp.h
@@ -38,7 +38,6 @@
 #define findpts_free          TOKEN_PASTE(PREFIXED_NAME(findpts_free_ ),D)
 #define findpts               TOKEN_PASTE(PREFIXED_NAME(findpts_      ),D)
 #define findpts_eval          TOKEN_PASTE(PREFIXED_NAME(findpts_eval_ ),D)
-#define findpts_local_eval    TOKEN_PASTE(PREFIXED_NAME(findpts_local_eval_ ),D)
 #define setup_fev_aux         TOKEN_PASTE(setup_fev_aux_,D)
 
 struct hash_data {

--- a/src/findpts_local_imp.h
+++ b/src/findpts_local_imp.h
@@ -466,7 +466,7 @@ void findpts_local_eval(
   const uint npt,
   const double *const in, struct findpts_local_data *const fd)
 {
-  findpts_local_eval(
+  findptsms_local_eval(
   out_base,out_stride,
    el_base,el_stride,
     r_base,r_stride,


### PR DESCRIPTION
- Fix infinite recursion bug: I think this is a typo for `findptsms_local_eval`, but correct me if I am wrong!
- Fix misleading indentation bug
- Remove duplicate `findpts_local_eval` macro definition

All warnings caught when compiling with GCC 12 on Amazon Linux 2.